### PR TITLE
Implement MongoDB Context State Management

### DIFF
--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/AgentJMongoDB.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/AgentJMongoDB.java
@@ -33,12 +33,29 @@ public class AgentJMongoDB {
         return database.getCollection(collectionName, documentClass);
     }
 
+    /**
+     * Finds a single document in the collection that matches the filter.
+     *
+     * @param collection the collection to find the document in
+     * @param filter the filter to match the document
+     * @param convertor the convertor to convert the document to a record
+     * @return the record if found, or null if not found
+     */
     public <T, D> T findOne(MongoCollection<D> collection,
                                Bson filter, Convertor<D, T> convertor) {
         D document = collection.find(filter).first();
         return Optional.ofNullable(document).map(convertor::convert).orElse(null);
     }
 
+    /**
+     * Finds all documents in the collection that match the filter.
+     *
+     * @param collection the collection to find documents in
+     * @param filter the filter to match documents
+     * @param sort the sort order for the documents
+     * @param convertor the convertor to convert documents to records
+     * @return a list of records
+     */
     public <T, D> List<T> find(MongoCollection<D> collection,
                             Bson filter,
                             Bson sort, Convertor<D, T> convertor) {
@@ -46,6 +63,13 @@ public class AgentJMongoDB {
         return iterableDocs.map(convertor::convert).into(new ArrayList<>());
     }
 
+    /**
+     * Inserts a record into the collection.
+     *
+     * @param collection the collection to insert the record into
+     * @param record the record to be inserted
+     * @param convertor the convertor to convert the record to a document
+     */
     public <T, D> void insertOne(MongoCollection<D> collection, T record,
                               Convertor<T, D> convertor) {
 
@@ -54,6 +78,13 @@ public class AgentJMongoDB {
                 .map(collection::insertOne);
     }
 
+    /**
+     * Inserts a list of records into the collection.
+     *
+     * @param collection the collection to insert the records into
+     * @param records the records to be inserted
+     * @param convertor the convertor to convert the records to documents
+     */
     public <T, D> void insertMany(MongoCollection<D> collection,
                                List<? extends T> records,
                                Convertor<T, D> convertor) {
@@ -65,6 +96,15 @@ public class AgentJMongoDB {
         collection.insertMany(documents);
     }
 
+    /**
+     * Upserts a document in the collection.
+     *
+     * @param collection the collection to upsert the document in
+     * @param filter the filter to match the document to be upserted
+     * @param record the record to be upserted
+     * @param convertor the convertor to convert the record to a document
+     * @return the upserted document
+     */
     public <T, D extends AgentJDocument> D upsert(MongoCollection<D> collection, Bson filter, T record,
                                                      Convertor<T, D> convertor) {
         Instant now = Instant.now();

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/AgentJMongoDB.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/AgentJMongoDB.java
@@ -2,12 +2,15 @@ package ai.agentscentral.mongodb;
 
 import ai.agentscentral.core.convertors.Convertor;
 import ai.agentscentral.mongodb.config.MongoDBConfig;
-import ai.agentscentral.mongodb.model.MessageDocument;
+import ai.agentscentral.mongodb.model.AgentJDocument;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.FindOneAndReplaceOptions;
+import com.mongodb.client.model.ReturnDocument;
 import org.bson.conversions.Bson;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -30,37 +33,51 @@ public class AgentJMongoDB {
         return database.getCollection(collectionName, documentClass);
     }
 
-    public <T> T findOne(MongoCollection<MessageDocument> collection,
-                               Bson filter,
-                               Bson sort, Convertor<MessageDocument, T> convertor) {
-        MessageDocument document = collection.find(filter).sort(sort).first();
+    public <T, D> T findOne(MongoCollection<D> collection,
+                               Bson filter, Convertor<D, T> convertor) {
+        D document = collection.find(filter).first();
         return Optional.ofNullable(document).map(convertor::convert).orElse(null);
     }
 
-    public <T> List<T> find(MongoCollection<MessageDocument> collection,
+    public <T, D> List<T> find(MongoCollection<D> collection,
                             Bson filter,
-                            Bson sort, Convertor<MessageDocument, T> convertor) {
-        FindIterable<MessageDocument> iterableDocs = collection.find(filter).sort(sort);
+                            Bson sort, Convertor<D, T> convertor) {
+        FindIterable<D> iterableDocs = collection.find(filter).sort(sort);
         return iterableDocs.map(convertor::convert).into(new ArrayList<>());
     }
 
-    public <T> void insertOne(MongoCollection<MessageDocument> collection, T record,
-                              Convertor<T, MessageDocument> convertor) {
+    public <T, D> void insertOne(MongoCollection<D> collection, T record,
+                              Convertor<T, D> convertor) {
 
         Optional.of(record)
                 .map(convertor::convert)
                 .map(collection::insertOne);
     }
 
-    public <T> void insertMany(MongoCollection<MessageDocument> collection,
+    public <T, D> void insertMany(MongoCollection<D> collection,
                                List<? extends T> records,
-                               Convertor<T, MessageDocument> convertor) {
+                               Convertor<T, D> convertor) {
 
 
-        final List<MessageDocument> documents = records.stream()
+        final List<D> documents = records.stream()
                 .map(convertor::convert).toList();
 
         collection.insertMany(documents);
     }
 
+    public <T, D extends AgentJDocument> D upsert(MongoCollection<D> collection, Bson filter, T record,
+                                                     Convertor<T, D> convertor) {
+        Instant now = Instant.now();
+
+        D document = convertor.convert(record);
+        document.setUpdatedAt(now);
+
+        boolean exists = collection.countDocuments(filter) > 0;
+        if (!exists) {
+            document.setCreatedAt(now);
+        }
+
+        return collection.findOneAndReplace(filter, document,
+                new FindOneAndReplaceOptions().upsert(true).returnDocument(ReturnDocument.AFTER));
+    }
 }

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/config/MongoDBConfig.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/config/MongoDBConfig.java
@@ -15,6 +15,13 @@ public class MongoDBConfig {
     private static MongoClient mongoClient;
     private static final String DEFAULT_DATABASE_NAME = "agentj_mongodb";
 
+    /**
+     * Create or Retrieve the MongoDB database instance.
+     *
+     * @param connectionString the connection string for the MongoDB database
+     * @param databaseName the name of the database to retrieve
+     * @return the MongoDB database instance
+     */
     public static synchronized MongoDatabase getMongoDatabase(String connectionString, String databaseName) {
         if (mongoClient == null) {
             mongoClient = MongoClients.create(connectionString);

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/context/MongoDBContextManager.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/context/MongoDBContextManager.java
@@ -30,6 +30,12 @@ public class MongoDBContextManager implements ContextManager {
         this.contextCollection = agentJMongoDB.getCollection(contextCollectionName, MessageDocument.class);
     }
 
+    /**
+     * Retrieves the context message list for the specified context ID.
+     *
+     * @param contextId the unique identifier of the context message list
+     * @return a List of Messages if found, or empty if not found
+     */
     @Override
     public List<Message> getContext(String contextId) {
         Bson filter = Filters.eq("contextId", contextId);
@@ -37,6 +43,13 @@ public class MongoDBContextManager implements ContextManager {
         return agentJMongoDB.find(contextCollection, filter, sort, toMessageConverter);
     }
 
+    /**
+     * Adds a list of messages to the context for the specified context ID.
+     *
+     * @param contextId the unique identifier of the context message list
+     * @param newMessages the list of messages to be added
+     * @throws IllegalArgumentException if the messages list is null or empty
+     */
     @Override
     public void addContext(String contextId, List<? extends Message> newMessages) {
         if (newMessages == null || newMessages.isEmpty()) {

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/contextstate/MongoDBContextStateManager.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/contextstate/MongoDBContextStateManager.java
@@ -2,8 +2,16 @@ package ai.agentscentral.mongodb.contextstate;
 
 import ai.agentscentral.core.context.ContextState;
 import ai.agentscentral.core.context.ContextStateManager;
+import ai.agentscentral.mongodb.AgentJMongoDB;
+import ai.agentscentral.mongodb.model.ContextStateDocument;
+import com.mongodb.client.MongoCollection;
+import org.bson.conversions.Bson;
 
 import java.util.Optional;
+
+import static ai.agentscentral.mongodb.convertors.ContextStateConverter.contextStateToDocConverter;
+import static ai.agentscentral.mongodb.convertors.ContextStateConverter.docToContextStateConverter;
+import static com.mongodb.client.model.Filters.eq;
 
 /**
  * MongoDBContextStateManager
@@ -12,13 +20,32 @@ import java.util.Optional;
  * @author Rizwan Idrees
  */
 public class MongoDBContextStateManager implements ContextStateManager {
+
+    private final AgentJMongoDB agentJMongoDB;
+    private final MongoCollection<ContextStateDocument> contextStateCollection;
+
+    public MongoDBContextStateManager(AgentJMongoDB agentJMongoDB, String contextStateCollectionName) {
+        this.agentJMongoDB = agentJMongoDB;
+        this.contextStateCollection = agentJMongoDB.getCollection(contextStateCollectionName, ContextStateDocument.class);
+    }
+
     @Override
-    public Optional<ContextState> getCurrentState(String sessionId) {
-        return Optional.empty();
+    public Optional<ContextState> getCurrentState(String contextId) {
+        Bson filter = eq("contextId", contextId);
+        ContextState contextState = agentJMongoDB.findOne(contextStateCollection, filter, docToContextStateConverter);
+        return Optional.ofNullable(contextState);
     }
 
     @Override
     public ContextState updateState(ContextState newState) {
-        return null;
+        if (newState == null) {
+            throw new IllegalArgumentException("New state cannot be null");
+        }
+
+        Bson filter = eq("contextId", newState.contextId());
+
+        ContextStateDocument contextStateDocument = agentJMongoDB.upsert(contextStateCollection, filter, newState,
+                contextStateToDocConverter);
+        return docToContextStateConverter.convert(contextStateDocument);
     }
 }

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/contextstate/MongoDBContextStateManager.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/contextstate/MongoDBContextStateManager.java
@@ -29,6 +29,12 @@ public class MongoDBContextStateManager implements ContextStateManager {
         this.contextStateCollection = agentJMongoDB.getCollection(contextStateCollectionName, ContextStateDocument.class);
     }
 
+    /**
+     * Retrieves the current state for the specified context ID.
+     *
+     * @param contextId the unique identifier of the context whose state is to be retrieved
+     * @return an Optional containing the ContextState if found, or empty if not found
+     */
     @Override
     public Optional<ContextState> getCurrentState(String contextId) {
         Bson filter = eq("contextId", contextId);
@@ -36,6 +42,13 @@ public class MongoDBContextStateManager implements ContextStateManager {
         return Optional.ofNullable(contextState);
     }
 
+    /**
+     * Updates the state for the specified context ID.
+     *
+     * @param newState the new state to be updated
+     * @return the updated ContextState
+     * @throws IllegalArgumentException if the new state is null
+     */
     @Override
     public ContextState updateState(ContextState newState) {
         if (newState == null) {

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/convertors/ContextStateConverter.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/convertors/ContextStateConverter.java
@@ -1,0 +1,37 @@
+package ai.agentscentral.mongodb.convertors;
+
+import ai.agentscentral.core.context.ContextState;
+import ai.agentscentral.core.context.DefaultContextState;
+import ai.agentscentral.core.convertors.Convertor;
+import ai.agentscentral.mongodb.enums.ContextStateType;
+import ai.agentscentral.mongodb.model.ContextStateDocument;
+
+public class ContextStateConverter {
+
+    // Converter to convert ContextState -> ContextStateDocument
+    public static Convertor<ContextState, ContextStateDocument> contextStateToDocConverter
+            = (contextState) -> {
+        ContextStateDocument contextStateDocument = new ContextStateDocument();
+        contextStateDocument.setContextId(contextState.contextId());
+        contextStateDocument.setCurrentTeam(contextState.currentTeam());
+        contextStateDocument.setCurrentAgent(contextState.currentAgent());
+        contextStateDocument.setPartOfTeam(contextState.partOfTeam());
+
+        switch (contextState) {
+            case DefaultContextState defaultCS -> contextStateDocument.setType(ContextStateType.DEFAULT);
+            default -> throw new IllegalArgumentException("Unsupported context state type: " + contextState.getClass().getName());
+        }
+        return contextStateDocument;
+    };
+
+    // Converter to convert ContextStateDocument -> ContextState
+    public static Convertor<ContextStateDocument, ContextState> docToContextStateConverter
+            = (contextStateDocument) -> {
+        return switch (contextStateDocument.getType()) {
+            case DEFAULT -> new DefaultContextState(contextStateDocument.getContextId(),
+                    contextStateDocument.getCurrentTeam(), contextStateDocument.getCurrentAgent(),
+                    contextStateDocument.getPartOfTeam());
+            default -> throw new IllegalArgumentException("Unsupported context state document type: " + contextStateDocument.getType());
+        };
+    };
+}

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/convertors/ContextStateConverter.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/convertors/ContextStateConverter.java
@@ -6,6 +6,11 @@ import ai.agentscentral.core.convertors.Convertor;
 import ai.agentscentral.mongodb.enums.ContextStateType;
 import ai.agentscentral.mongodb.model.ContextStateDocument;
 
+/**
+ * ContextStateConverter
+ *
+ * @author Mustafa Bhuiyan
+ */
 public class ContextStateConverter {
 
     // Converter to convert ContextState -> ContextStateDocument

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/enums/ContextStateType.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/enums/ContextStateType.java
@@ -1,0 +1,5 @@
+package ai.agentscentral.mongodb.enums;
+
+public enum ContextStateType {
+    DEFAULT
+}

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/enums/ContextStateType.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/enums/ContextStateType.java
@@ -1,5 +1,10 @@
 package ai.agentscentral.mongodb.enums;
 
+/**
+ * ContextStateType
+ *
+ * @author Mustafa Bhuiyan
+ */
 public enum ContextStateType {
     DEFAULT
 }

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/model/AgentJDocument.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/model/AgentJDocument.java
@@ -4,6 +4,11 @@ import org.bson.types.ObjectId;
 
 import java.time.Instant;
 
+/**
+ * AgentJDocument
+ *
+ * @author Mustafa Bhuiyan
+ */
 public abstract class AgentJDocument {
     protected ObjectId id;
     protected Instant createdAt;

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/model/AgentJDocument.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/model/AgentJDocument.java
@@ -1,0 +1,35 @@
+package ai.agentscentral.mongodb.model;
+
+import org.bson.types.ObjectId;
+
+import java.time.Instant;
+
+public abstract class AgentJDocument {
+    protected ObjectId id;
+    protected Instant createdAt;
+    protected Instant updatedAt;
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/model/ContextStateDocument.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/model/ContextStateDocument.java
@@ -5,6 +5,11 @@ import org.bson.types.ObjectId;
 
 import java.time.Instant;
 
+/**
+ * ContextStateDocument
+ *
+ * @author Mustafa Bhuiyan
+ */
 public class ContextStateDocument extends AgentJDocument {
     private ContextStateType type;
     private String contextId;

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/model/ContextStateDocument.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/model/ContextStateDocument.java
@@ -1,0 +1,68 @@
+package ai.agentscentral.mongodb.model;
+
+import ai.agentscentral.mongodb.enums.ContextStateType;
+import org.bson.types.ObjectId;
+
+import java.time.Instant;
+
+public class ContextStateDocument extends AgentJDocument {
+    private ContextStateType type;
+    private String contextId;
+    private String currentTeam;
+    private String currentAgent;
+    private String partOfTeam;
+
+    public ContextStateDocument() {}
+
+    public ContextStateDocument(ObjectId id, ContextStateType type, String contextId, String currentTeam,
+                                String currentAgent, String partOfTeam, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.type = type;
+        this.contextId = contextId;
+        this.currentTeam = currentTeam;
+        this.currentAgent = currentAgent;
+        this.partOfTeam = partOfTeam;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public ContextStateType getType() {
+        return type;
+    }
+
+    public void setType(ContextStateType type) {
+        this.type = type;
+    }
+
+    public String getContextId() {
+        return contextId;
+    }
+
+    public void setContextId(String contextId) {
+        this.contextId = contextId;
+    }
+
+    public String getCurrentTeam() {
+        return currentTeam;
+    }
+
+    public void setCurrentTeam(String currentTeam) {
+        this.currentTeam = currentTeam;
+    }
+
+    public String getCurrentAgent() {
+        return currentAgent;
+    }
+
+    public void setCurrentAgent(String currentAgent) {
+        this.currentAgent = currentAgent;
+    }
+
+    public String getPartOfTeam() {
+        return partOfTeam;
+    }
+
+    public void setPartOfTeam(String partOfTeam) {
+        this.partOfTeam = partOfTeam;
+    }
+}

--- a/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/model/MessageDocument.java
+++ b/agentj-mongodb/src/main/java/ai/agentscentral/mongodb/model/MessageDocument.java
@@ -3,6 +3,7 @@ package ai.agentscentral.mongodb.model;
 import ai.agentscentral.mongodb.enums.MessageType;
 import org.bson.types.ObjectId;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -11,8 +12,7 @@ import java.util.Map;
  *
  * @author Mustafa Bhuiyan
  */
-public class MessageDocument {
-    private ObjectId id;
+public class MessageDocument extends AgentJDocument {
     private MessageType messageType;
 
     // Common fields for all message types
@@ -56,7 +56,8 @@ public class MessageDocument {
             String agentName,
             String toolCallId,
             String toolName,
-            Map<String, String> interruptParameterValues) {
+            Map<String, String> interruptParameterValues,
+            Instant createdAt, Instant updatedAt) {
         this.id = id;
         this.messageType = messageType;
         this.contextId = contextId;
@@ -70,17 +71,11 @@ public class MessageDocument {
         this.toolCallId = toolCallId;
         this.toolName = toolName;
         this.interruptParameterValues = interruptParameterValues;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 
     // Getters and Setters
-
-    public ObjectId getId() {
-        return id;
-    }
-
-    public void setId(ObjectId id) {
-        this.id = id;
-    }
 
     public MessageType getMessageType() {
         return messageType;

--- a/agentj-mongodb/src/test/java/ai/agentscentral/mongodb/config/MongoDBTestConfig.java
+++ b/agentj-mongodb/src/test/java/ai/agentscentral/mongodb/config/MongoDBTestConfig.java
@@ -23,6 +23,11 @@ public class MongoDBTestConfig {
     private static AgentJMongoDB agentJMongoDB;
     private static final Logger logger = LoggerFactory.getLogger(MongoDBTestConfig.class);
 
+    /**
+     * Starts the MongoDB test container and creates the AgentJMongoDB instance.
+     *
+     * @return the AgentJMongoDB instance
+     */
     public static AgentJMongoDB getAgentJMongoDB() {
         if (agentJMongoDB == null) {
             if (!mongoDBContainer.isRunning()) {

--- a/agentj-mongodb/src/test/java/ai/agentscentral/mongodb/context/MongoDBContextStateManagerIntegrationTest.java
+++ b/agentj-mongodb/src/test/java/ai/agentscentral/mongodb/context/MongoDBContextStateManagerIntegrationTest.java
@@ -1,0 +1,134 @@
+package ai.agentscentral.mongodb.context;
+
+import ai.agentscentral.core.context.ContextState;
+import ai.agentscentral.core.context.DefaultContextState;
+import ai.agentscentral.mongodb.AgentJMongoDB;
+import ai.agentscentral.mongodb.config.MongoDBTestConfig;
+import ai.agentscentral.mongodb.contextstate.MongoDBContextStateManager;
+import ai.agentscentral.mongodb.model.ContextStateDocument;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MongoDBContextStateManagerIntegrationTest {
+
+    private static MongoDBContextStateManager contextStateManager;
+    private static final AgentJMongoDB agentJMongoDB = MongoDBTestConfig.getAgentJMongoDB();
+    private static final String CONTEXT_STATE_COLLECTION_NAME = "context_states";
+    private static final String TEST_CONTEXT_ID = "test-context-1";
+    private static final String TEST_TEAM = "test-team";
+    private static final String TEST_AGENT = "test-agent";
+    private static final String TEST_PART_OF_TEAM = "test-part-of-team";
+
+    @BeforeAll
+    public static void setUp() {
+        contextStateManager = new MongoDBContextStateManager(agentJMongoDB, CONTEXT_STATE_COLLECTION_NAME);
+    }
+
+    @BeforeEach
+    public void cleanUp() {
+        MongoDBTestConfig.clearCollection(
+                agentJMongoDB.getCollection(CONTEXT_STATE_COLLECTION_NAME, ContextStateDocument.class));
+    }
+
+    @Test
+    public void test_getCurrentState_whenContextDoesNotExist_shouldReturnEmptyOptional() {
+        // Act
+        Optional<ContextState> result = contextStateManager.getCurrentState("non-existent-id");
+        
+        // Assert
+        assertTrue(result.isEmpty(), "Should return empty optional for non-existent context ID");
+    }
+
+    @Test
+    public void test_getCurrentState_whenContextIdIsNull_shouldReturnEmptyOptional() {
+        // Act
+        Optional<ContextState> result = contextStateManager.getCurrentState(null);
+
+        // Assert
+        assertTrue(result.isEmpty(), "Should return empty optional for null context ID");
+    }
+
+    @Test
+    public void test_updateStateAndGetCurrentState_whenContextStateIsSaved_shouldReturnSavedState() {
+        // Arrange
+        ContextState originalState = new DefaultContextState(
+                TEST_CONTEXT_ID,
+                TEST_TEAM,
+                TEST_AGENT,
+                TEST_PART_OF_TEAM
+        );
+
+        // Act - Save the state
+        ContextState savedState = contextStateManager.updateState(originalState);
+        
+        // Assert - Check if the saved state matches the original
+        assertNotNull(savedState, "Saved state should not be null");
+        assertEquals(TEST_CONTEXT_ID, savedState.contextId());
+        assertEquals(TEST_TEAM, savedState.currentTeam());
+        assertEquals(TEST_AGENT, savedState.currentAgent());
+        assertEquals(TEST_PART_OF_TEAM, savedState.partOfTeam());
+
+        // Act - Retrieve the state
+        Optional<ContextState> retrievedStateOpt = contextStateManager.getCurrentState(TEST_CONTEXT_ID);
+        
+        // Assert - Check if the retrieved state matches the saved state
+        assertTrue(retrievedStateOpt.isPresent(), "State should be present");
+        ContextState retrievedState = retrievedStateOpt.get();
+        assertEquals(savedState.contextId(), retrievedState.contextId());
+        assertEquals(savedState.currentTeam(), retrievedState.currentTeam());
+        assertEquals(savedState.currentAgent(), retrievedState.currentAgent());
+        assertEquals(savedState.partOfTeam(), retrievedState.partOfTeam());
+    }
+
+    @Test
+    public void test_updateState_whenContextStateExists_shouldUpdateExistingState() {
+        // Arrange - Create and save initial state
+        ContextState initialState = new DefaultContextState(
+                TEST_CONTEXT_ID,
+                "initial-team",
+                "initial-agent",
+                "initial-part-of-team"
+        );
+        contextStateManager.updateState(initialState);
+
+        // Create updated state with same context ID but different values
+        ContextState updatedState = new DefaultContextState(
+                TEST_CONTEXT_ID,
+                "updated-team",
+                "updated-agent",
+                "updated-part-of-team"
+        );
+
+        // Act - Update the state
+        ContextState result = contextStateManager.updateState(updatedState);
+
+        // Assert - Check if the updated state was saved correctly
+        assertNotNull(result, "Updated state should not be null");
+        assertEquals(TEST_CONTEXT_ID, result.contextId());
+        assertEquals("updated-team", result.currentTeam());
+        assertEquals("updated-agent", result.currentAgent());
+        assertEquals("updated-part-of-team", result.partOfTeam());
+
+        // Verify the state was updated in the database
+        Optional<ContextState> retrievedState = contextStateManager.getCurrentState(TEST_CONTEXT_ID);
+        assertTrue(retrievedState.isPresent(), "State should be present after update");
+        assertEquals("updated-team", retrievedState.get().currentTeam());
+    }
+
+    @Test
+    public void test_updateState_whenStateIsNull_shouldThrowIllegalArgumentException() {
+        // Act & Assert
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> contextStateManager.updateState(null),
+                "Should throw IllegalArgumentException when state is null"
+        );
+        
+        assertEquals("New state cannot be null", exception.getMessage());
+    }
+}

--- a/agentj-mongodb/src/test/java/ai/agentscentral/mongodb/context/MongoDBContextStateManagerIntegrationTest.java
+++ b/agentj-mongodb/src/test/java/ai/agentscentral/mongodb/context/MongoDBContextStateManagerIntegrationTest.java
@@ -14,6 +14,11 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * MongoDBContextStateManagerIntegrationTest
+ *
+ * @author Mustafa Bhuiyan
+ */
 public class MongoDBContextStateManagerIntegrationTest {
 
     private static MongoDBContextStateManager contextStateManager;


### PR DESCRIPTION
This PR introduces the MongoDB implementation for context state management, including core functionality for persisting and retrieving context states. The implementation includes both the data access layer and comprehensive integration tests.

**Key Changes**

- [x] Implemented `MongoDBContextStateManager` with `get` and `upsert` context state operations.

- [x] Created `upsert` functionality in the `AgentJMongoDB` repository.

- [x] Enhanced `AgentJMongoDB` generic methods with generic Document class type - Added reusable data access patterns and efficient document updates through `upsert` operations, leveraging the `AgentJDocument` abstraction for type safety and consistency.

- [x] Added base `AgentJDocument` class for MongoDB document models - Provides common fields and methods for all MongoDB documents, ensuring consistency and reducing code duplication.

- [x] Added comprehensive integration tests for all context state operations

- [x] Enhanced audit field handling by extending `MessageDocument` from `AgentJMongoDB` and set the audit fields during insert operations.

- [x]  Added JavaDoc comments.